### PR TITLE
Add a sakai stylesheet

### DIFF
--- a/README.org
+++ b/README.org
@@ -62,6 +62,8 @@ Install the stylesheet of your choice according to your browser's method (e.g. u
   For [[http://planet.emacsen.org][Planet Emacsen]]
 - ~solarized-stackexchange-*.css~
   For StackExchange sites.  Not all sites are covered, but some of the main ones are.  Patches welcome.
+- ~solarized-sakai-*.css~
+  For sites hosted by [[https://sakaiproject.org/][sakai]], a popular course management program.
 
 ** Development                                                  :noexport_1:
 
@@ -93,4 +95,3 @@ This way, the Solarized color values are loaded first, followed by the dark- or 
 ** License
 
 Really?  Come on, it's just some CSS.  Just have fun and share!
-

--- a/css/solarized-sakai-dark.css
+++ b/css/solarized-sakai-dark.css
@@ -1,0 +1,73 @@
+* {
+  border-color: #657b83 !important;
+}
+a {
+  color: #268bd2 !important;
+}
+a:visited {
+  color: #6c71c4 !important;
+}
+body {
+  background-color: #002b36 !important;
+  color: #839496 !important;
+}
+html {
+  background-color: #002b36 !important;
+}
+input,
+textarea {
+  background-color: #073642 !important;
+  color: #839496 !important;
+}
+blockquote,
+pre {
+  background-color: #073642 !important;
+  color: #839496 !important;
+}
+* {
+  border-color: #657b83 !important;
+}
+a {
+  color: #268bd2 !important;
+}
+a:visited {
+  color: #6c71c4 !important;
+}
+body {
+  background-color: #002b36 !important;
+  color: #839496 !important;
+}
+html {
+  background-color: #002b36 !important;
+}
+input,
+textarea {
+  background-color: #073642 !important;
+  color: #839496 !important;
+}
+tr:hover,
+blockquote,
+pre {
+  background-color: #073642 !important;
+  color: #839496 !important;
+}
+#toolMenu li {
+  background-color: #002b36 !important;
+}
+.navPanel,
+.navIntraTool {
+  background-color: #002b36 !important;
+}
+.sakaiCopyrightInfo {
+  color: #839496 !important;
+}
+.listHier th {
+  background-color: #094352 !important;
+}
+ul.makeMenu {
+  background: #094352;
+  border: 1px solid #094352 !important;
+}
+tr.external {
+  background-color: #094352 !important;
+}

--- a/css/solarized-sakai-dark.css
+++ b/css/solarized-sakai-dark.css
@@ -58,6 +58,7 @@ pre {
 .navIntraTool {
   background-color: #002b36 !important;
 }
+.instruction,
 .sakaiCopyrightInfo {
   color: #839496 !important;
 }
@@ -65,7 +66,7 @@ pre {
   background-color: #094352 !important;
 }
 ul.makeMenu {
-  background: #094352;
+  background-color: #094352 !important;
   border: 1px solid #094352 !important;
 }
 tr.external {

--- a/css/solarized-sakai-light.css
+++ b/css/solarized-sakai-light.css
@@ -58,6 +58,7 @@ pre {
 .navIntraTool {
   background-color: #fdf6e3 !important;
 }
+.instruction,
 .sakaiCopyrightInfo {
   color: #657b83 !important;
 }
@@ -65,7 +66,7 @@ pre {
   background-color: #e9e1c8 !important;
 }
 ul.makeMenu {
-  background: #e9e1c8;
+  background-color: #e9e1c8 !important;
   border: 1px solid #e9e1c8 !important;
 }
 tr.external {

--- a/css/solarized-sakai-light.css
+++ b/css/solarized-sakai-light.css
@@ -1,0 +1,73 @@
+* {
+  border-color: #839496 !important;
+}
+a {
+  color: #268bd2 !important;
+}
+a:visited {
+  color: #6c71c4 !important;
+}
+body {
+  background-color: #fdf6e3 !important;
+  color: #657b83 !important;
+}
+html {
+  background-color: #fdf6e3 !important;
+}
+input,
+textarea {
+  background-color: #eee8d5 !important;
+  color: #657b83 !important;
+}
+blockquote,
+pre {
+  background-color: #eee8d5 !important;
+  color: #657b83 !important;
+}
+* {
+  border-color: #839496 !important;
+}
+a {
+  color: #268bd2 !important;
+}
+a:visited {
+  color: #6c71c4 !important;
+}
+body {
+  background-color: #fdf6e3 !important;
+  color: #657b83 !important;
+}
+html {
+  background-color: #fdf6e3 !important;
+}
+input,
+textarea {
+  background-color: #eee8d5 !important;
+  color: #657b83 !important;
+}
+tr:hover,
+blockquote,
+pre {
+  background-color: #eee8d5 !important;
+  color: #657b83 !important;
+}
+#toolMenu li {
+  background-color: #fdf6e3 !important;
+}
+.navPanel,
+.navIntraTool {
+  background-color: #fdf6e3 !important;
+}
+.sakaiCopyrightInfo {
+  color: #657b83 !important;
+}
+.listHier th {
+  background-color: #e9e1c8 !important;
+}
+ul.makeMenu {
+  background: #e9e1c8;
+  border: 1px solid #e9e1c8 !important;
+}
+tr.external {
+  background-color: #e9e1c8 !important;
+}

--- a/sites/sakai.styl
+++ b/sites/sakai.styl
@@ -1,8 +1,6 @@
-// * generic.styl
+// * sakai.styl
 
-@require mixins
-
-// Generic rules for sites
+// Site-specific rules for sakai websites (t2.gatech.edu is a hosted example)
 
 // ** HTML elements
 *
@@ -25,6 +23,7 @@ textarea
     background-color highlight
     color()
 
+tr:hover
 blockquote,
 pre
     background-color highlight
@@ -47,7 +46,7 @@ pre
 
 ul.makeMenu
     background color-background-highlight-extra-less
-    border 1px solid color-background-highlight-extra-less !important
+    border 1px solid color-background-highlight-extra-less i
 
 tr.external
     background-color color-background-highlight-extra-less

--- a/sites/sakai.styl
+++ b/sites/sakai.styl
@@ -37,6 +37,7 @@ pre
 .navIntraTool
     background-color ()
 
+.instruction
 .sakaiCopyrightInfo
     color ()
 
@@ -45,7 +46,7 @@ pre
         background-color color-background-highlight-extra-less
 
 ul.makeMenu
-    background color-background-highlight-extra-less
+    background-color color-background-highlight-extra-less
     border 1px solid color-background-highlight-extra-less i
 
 tr.external

--- a/sites/sakai.styl
+++ b/sites/sakai.styl
@@ -1,0 +1,53 @@
+// * generic.styl
+
+@require mixins
+
+// Generic rules for sites
+
+// ** HTML elements
+*
+    border-color()
+a
+    a()
+a:visited
+    a visited
+
+body
+    background-color()
+    color()
+
+html
+    // Apparently some people set the bgcolor for HTML, not BODY...
+    background-color()
+
+input
+textarea
+    background-color highlight
+    color()
+
+blockquote,
+pre
+    background-color highlight
+    color()
+
+
+#toolMenu
+    li
+        background-color ()
+.navPanel
+.navIntraTool
+    background-color ()
+
+.sakaiCopyrightInfo
+    color ()
+
+.listHier
+    th
+        background-color color-background-highlight-extra-less
+
+ul.makeMenu
+    background color-background-highlight-extra-less
+    border 1px solid color-background-highlight-extra-less !important
+
+tr.external
+    background-color color-background-highlight-extra-less


### PR DESCRIPTION
Sakai is a open source classroom management software, that I use regularly. I've added a basic sakai stylesheet to fix some of the inconsistencies.

Can you please rebuild the CSS for me, when I did it it seemed to horribly break the 'all-sites' css file for me (with or without this patch). The sakai only ones seemed to work fine though.

Before:
![2017-10-08-010541_1487x485_scrot](https://user-images.githubusercontent.com/4349709/31314089-27a61478-abc5-11e7-989f-4cab38688149.png)
After:
![2017-10-08-010514_1587x483_scrot](https://user-images.githubusercontent.com/4349709/31314088-243d781c-abc5-11e7-85b5-a15a3ae5d8a2.png)

Obviously a lot more work is needed but this makes it bearable.

I'm really bad at CSS so please call me out on anything that looks wrong.