### PR TITLE
Fix custom link colors

### DIFF
--- a/css/solarized-all-sites-dark.css
+++ b/css/solarized-all-sites-dark.css
@@ -968,9 +968,6 @@ div.crp {
 #fbar {
   background-color: #073642 !important;
 }
-a {
-  color: #268bd2 !important;
-}
 table {
   background-color: #002b36 !important;
 }

--- a/css/solarized-all-sites-light.css
+++ b/css/solarized-all-sites-light.css
@@ -968,9 +968,6 @@ div.crp {
 #fbar {
   background-color: #eee8d5 !important;
 }
-a {
-  color: #268bd2 !important;
-}
 table {
   background-color: #fdf6e3 !important;
 }

--- a/css/solarized-hackernews-dark.css
+++ b/css/solarized-hackernews-dark.css
@@ -24,9 +24,6 @@ pre {
   background-color: #073642 !important;
   color: #839496 !important;
 }
-a {
-  color: #268bd2 !important;
-}
 table {
   background-color: #002b36 !important;
 }

--- a/css/solarized-hackernews-light.css
+++ b/css/solarized-hackernews-light.css
@@ -24,9 +24,6 @@ pre {
   background-color: #eee8d5 !important;
   color: #657b83 !important;
 }
-a {
-  color: #268bd2 !important;
-}
 table {
   background-color: #fdf6e3 !important;
 }

--- a/sites/hackernews.styl
+++ b/sites/hackernews.styl
@@ -1,8 +1,5 @@
 // ** Main
 
-a
-    color blue
-
 table
     background-color()
 


### PR DESCRIPTION
I'm planning on making my own variant of solarized-everything-css, one of the pros of this structure is the easy ability to restyle the web completely! (just like terminal applications, at least, that's my hope)

I found a small bug, preventing setting custom link colors set via `dark.styl` or similar.