### PR TITLE
Add reveal.js site specific quirk

### DIFF
--- a/sites/reveal.styl
+++ b/sites/reveal.styl
@@ -1,0 +1,7 @@
+// * reveal.styl
+
+// Site-specific rules for reveal.js slideshows
+
+// ** Reveal links
+.reveal
+    color()


### PR DESCRIPTION
Hi, I recently discovered that with solarized-everything-css, reveal css has black text on a dark background (hard to read), so I added a site specific quirk.

This brings up a larger question though, for tiny changes such as this, should these go in a 'quirks.styl' file, or in their own site files? I would imaging 'quirks.styl' would contain very simple changes like this one (with no chance of conflicting on other sites). 

What are your thoughts about it? (probably need to decide that before this is merged).