### PR TITLE
Github Fixes Part 3

### DIFF
--- a/sites/github.styl
+++ b/sites/github.styl
@@ -167,10 +167,6 @@ a.filter-item
 .text-diff-deleted
     color red
 
-.avatar
-.timeline-comment-avatar
-    filter opacity(50%)
-
 // ** Code syntax highlighting
 .blob-code
     background-color()

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -323,6 +323,11 @@ a.filter-item
     background-color color-background-highlight-extra
     color color-background
 
+// *** signed commit popup
+
+.signed-commit-header
+    background-color color-background
+
 // ** build
 .build-status-item
     background-color color-background-highlight-extra-less

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -169,7 +169,7 @@ a.filter-item
 
 .avatar
 .timeline-comment-avatar
-    filter opacity(50%)
+    filter opacity(75%)
 
 // ** Code syntax highlighting
 .blob-code

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -167,6 +167,10 @@ a.filter-item
 .text-diff-deleted
     color red
 
+.avatar
+.timeline-comment-avatar
+    filter opacity(50%)
+
 // ** Code syntax highlighting
 .blob-code
     background-color()

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -454,6 +454,9 @@ qul.branches-list
     &.octicon
         color emphasized
 
+.discussion-item-entity
+    color emphasized
+
 .discussion-timeline:before
     background-color color-border
 

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -301,6 +301,22 @@ a.filter-item
     background-color green
     color color-background
 
+// *** branch popup
+.select-menu-filters
+    background-color color-background-highlight-extra-less-less
+    color emphasized
+
+// branch tabs
+.js-select-menu-tab
+    background-color color-background-highlight-extra-less
+    color emphasized
+
+// branch selected tabs
+.select-menu-tabs a.selected
+.select-menu-tab-nav.selected
+    background-color color-background-highlight-extra
+    color color-background
+
 // ** build
 .build-status-item
     background-color color-background-highlight-extra-less

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -477,6 +477,8 @@ qul.branches-list
         color emphasized
 
 .discussion-item-entity
+.discussion-item .renamed-was
+.discussion-item .renamed-is
     color emphasized
 
 .discussion-timeline:before

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -232,6 +232,16 @@ a.filter-item
     color green
     bold()
 
+// + signs
+.pl-mi1
+    color green
+    background-color transparent
+
+// - signs
+.pl-md
+    color red
+    background-color transparent
+
 // ** .border-*
 
 .border-bottom


### PR DESCRIPTION
Hi, I've gone and made a few more github fixes.

- `+` and `-` colors in code block comments don't have a white background anymore
- Fixed some messages being dark in PR history
![2017-11-14-010651_731x86_scrot](https://user-images.githubusercontent.com/4349709/32765647-6755b5ca-c8d9-11e7-9bb8-0b41a8264864.png)
![2017-11-14-012032_595x75_scrot](https://user-images.githubusercontent.com/4349709/32765767-0e177092-c8da-11e7-9258-cf7d6d845d9d.png)

- [possibly contoversial] I upgraded my browser and I noticed github profile pictures are a bit dark. Is there a reason for them dimmed? I added a commit that turned that off.
![2017-11-14-010714_662x433_scrot](https://user-images.githubusercontent.com/4349709/32765648-67656de4-c8d9-11e7-9dc8-4c0de6d479d9.png)
- Fix branch popups (might need a bit more work, but this is a lot better than before)
![2017-11-14-010732_353x298_scrot](https://user-images.githubusercontent.com/4349709/32765649-67734ca2-c8d9-11e7-95a7-95509b5e77a4.png)
- Fix signed commit popups
![2017-11-14-011240_382x333_scrot](https://user-images.githubusercontent.com/4349709/32765650-6780e9a2-c8d9-11e7-8669-015d3ef4f6c3.png)

Let me know if you see any issues! :smile: 

This should be very easy to merge into `multi-theme` as it's only touching styl files.