### PR TITLE
Fixes for new github homescreen

### DIFF
--- a/css/apprentice/apprentice-all-sites.css
+++ b/css/apprentice/apprentice-all-sites.css
@@ -99,8 +99,22 @@ pre {
   background-color: #585858 !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #bcbcbc !important;
+}
+.Box {
+  background-color: #262626 !important;
+  color: #ff8700 !important;
+  border: 1px solid #800080 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #800080 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #444 !important;
 }
 .bg-white {
   background-color: #262626 !important;

--- a/css/apprentice/apprentice-github.css
+++ b/css/apprentice/apprentice-github.css
@@ -31,8 +31,22 @@ pre {
   background-color: #585858 !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #bcbcbc !important;
+}
+.Box {
+  background-color: #262626 !important;
+  color: #ff8700 !important;
+  border: 1px solid #800080 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #800080 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #444 !important;
 }
 .bg-white {
   background-color: #262626 !important;

--- a/css/darculized/darculized-all-sites.css
+++ b/css/darculized/darculized-all-sites.css
@@ -99,8 +99,22 @@ pre {
   background-color: #323232 !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #909396 !important;
+}
+.Box {
+  background-color: #262626 !important;
+  color: #a6aaab !important;
+  border: 1px solid #909396 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #909396 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #363636 !important;
 }
 .bg-white {
   background-color: #262626 !important;

--- a/css/darculized/darculized-github.css
+++ b/css/darculized/darculized-github.css
@@ -31,8 +31,22 @@ pre {
   background-color: #323232 !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #909396 !important;
+}
+.Box {
+  background-color: #262626 !important;
+  color: #a6aaab !important;
+  border: 1px solid #909396 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #909396 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #363636 !important;
 }
 .bg-white {
   background-color: #262626 !important;

--- a/css/gruvbox/gruvbox-all-sites.css
+++ b/css/gruvbox/gruvbox-all-sites.css
@@ -99,8 +99,22 @@ pre {
   background-color: #403c3a !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #83a598 !important;
+}
+.Box {
+  background-color: #282828 !important;
+  color: #8ec07c !important;
+  border: 1px solid #fabd2f !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #fabd2f !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #44403e !important;
 }
 .bg-white {
   background-color: #282828 !important;

--- a/css/gruvbox/gruvbox-github.css
+++ b/css/gruvbox/gruvbox-github.css
@@ -31,8 +31,22 @@ pre {
   background-color: #403c3a !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #83a598 !important;
+}
+.Box {
+  background-color: #282828 !important;
+  color: #8ec07c !important;
+  border: 1px solid #fabd2f !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #fabd2f !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #44403e !important;
 }
 .bg-white {
   background-color: #282828 !important;

--- a/css/solarized-dark/solarized-dark-all-sites.css
+++ b/css/solarized-dark/solarized-dark-all-sites.css
@@ -99,8 +99,22 @@ pre {
   background-color: #083c4a !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #839496 !important;
+}
+.Box {
+  background-color: #002b36 !important;
+  color: #93a1a1 !important;
+  border: 1px solid #657b83 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #657b83 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #094352 !important;
 }
 .bg-white {
   background-color: #002b36 !important;

--- a/css/solarized-dark/solarized-dark-github.css
+++ b/css/solarized-dark/solarized-dark-github.css
@@ -31,8 +31,22 @@ pre {
   background-color: #083c4a !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #839496 !important;
+}
+.Box {
+  background-color: #002b36 !important;
+  color: #93a1a1 !important;
+  border: 1px solid #657b83 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #657b83 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #094352 !important;
 }
 .bg-white {
   background-color: #002b36 !important;

--- a/css/solarized-light/solarized-light-all-sites.css
+++ b/css/solarized-light/solarized-light-all-sites.css
@@ -99,8 +99,22 @@ pre {
   background-color: #ebe4cf !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #657b83 !important;
+}
+.Box {
+  background-color: #fdf6e3 !important;
+  color: #586e75 !important;
+  border: 1px solid #839496 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #839496 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #e9e1c8 !important;
 }
 .bg-white {
   background-color: #fdf6e3 !important;

--- a/css/solarized-light/solarized-light-github.css
+++ b/css/solarized-light/solarized-light-github.css
@@ -31,8 +31,22 @@ pre {
   background-color: #ebe4cf !important;
 }
 .link-gray-dark,
-.text-gray-dark {
+.text-gray-dark,
+.text-gray {
   color: #657b83 !important;
+}
+.Box {
+  background-color: #fdf6e3 !important;
+  color: #586e75 !important;
+  border: 1px solid #839496 !important;
+}
+.Box-header,
+.Box-body {
+  border-color: #839496 !important;
+}
+.Box-header,
+.Box-row--hover-blue:hover {
+  background-color: #e9e1c8 !important;
 }
 .bg-white {
   background-color: #fdf6e3 !important;

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -14,7 +14,22 @@
 
 .link-gray-dark
 .text-gray-dark
+.text-gray
     color()
+
+.Box
+    background-color color-background
+    color emphasized
+    border 1px solid color-border i
+
+.Box-header
+.Box-body
+.Box-row
+    border-color color-border
+
+.Box-header
+.Box-row--hover-blue:hover
+    background-color color-background-highlight-extra-less
 
 .bg-white
     // Nope!
@@ -247,6 +262,10 @@ a.filter-item
 .border-bottom
 .border-top
     border-color color-background-highlight
+
+// matches homescreen dynamic box but not anything else
+li.d-flex.border-top
+    border-color color-border
 
 // ** boxed-group
 .boxed-group

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -24,7 +24,6 @@
 
 .Box-header
 .Box-body
-.Box-row
     border-color color-border
 
 .Box-header
@@ -262,10 +261,6 @@ a.filter-item
 .border-bottom
 .border-top
     border-color color-background-highlight
-
-// matches homescreen dynamic box but not anything else
-li.d-flex.border-top
-    border-color color-border
 
 // ** boxed-group
 .boxed-group


### PR DESCRIPTION
I haven't regenerated CSS yet, so the review is easier.

![2018-05-25-140421_1001x853_scrot](https://user-images.githubusercontent.com/4349709/40566248-609dbd5e-605f-11e8-8f7d-3e4fccb78077.png)

I edited a few "generic" elements for this, so I'll have to see if this affects any other elements. I don't see any so far though.