### PR TITLE
fix the invisible dark text color

### DIFF
--- a/sites/github.styl
+++ b/sites/github.styl
@@ -223,6 +223,8 @@ a.filter-item
     color cyan
 
 .pl-s
+.pl-sr
+.pl-s1
     color cyan
 
 .pl-smi


### PR DESCRIPTION
The `pl-s1` and `pl-sr` is cause invisible issue in javascript and typescript code. 
### pl-s1-before
![pl-s1-before](https://user-images.githubusercontent.com/2096033/48431525-ea05ba80-e73f-11e8-9293-f5f6e8e75988.png)
### pl-sr-before
![pl-sr-before](https://user-images.githubusercontent.com/2096033/48431528-ec681480-e73f-11e8-9ab0-85d3d5137442.png)

## After the fix:
### pl-s1-after
![pl-s1-after](https://user-images.githubusercontent.com/2096033/48431567-0570c580-e740-11e8-8a45-fd3a2552762f.png)
### pl-sr-after
![pl-sr-after](https://user-images.githubusercontent.com/2096033/48431575-07d31f80-e740-11e8-9e4c-74bfc0eb9cbb.png)


Please let me know if you have any concerns.