### PR TITLE
make check color consistent

### DIFF
--- a/sites/github.styl
+++ b/sites/github.styl
@@ -649,7 +649,7 @@ a.label
 .octicon-x
     color red
 .octicon-check
-    color green
+    color black
 .octicon-primitive-dot
     color yellow
 


### PR DESCRIPTION
## check and the surrounding circle have the same color. Changing it to black to keep consistent.

### before
<img width="815" alt="check-before" src="https://user-images.githubusercontent.com/2096033/48443619-bfc3f500-e75f-11e8-9e19-8383405ea613.png">


### after
<img width="785" alt="check-after" src="https://user-images.githubusercontent.com/2096033/48443625-c5213f80-e75f-11e8-865f-016d2054aea8.png">

Please let me know if you have any concerns. Thanks. 