### PR TITLE
nav with updated class name

### DIFF
--- a/sites/github.styl
+++ b/sites/github.styl
@@ -943,7 +943,7 @@ a.tabnav-tab
 
 // ** underline-nav
 
-.underline-nav-item
+.UnderlineNav-item
     color()
 
     &.selected
@@ -954,7 +954,6 @@ a.tabnav-tab
 
 .user-profile-nav
     background-color highlight
-    border-color()
 
 .user-profile-sticky-bar
     &:after


### PR DESCRIPTION
Github updated the nav class name form `.underline-nav-item` to `UnderlineNav-item`, also need to remove the overall nav border color to make it consistent.
<img width="568" alt="dom" src="https://user-images.githubusercontent.com/2096033/48445887-be95c680-e765-11e8-9194-38eb3dc4c32b.png">


### before
<img width="797" alt="border-before" src="https://user-images.githubusercontent.com/2096033/48445833-9908bd00-e765-11e8-895a-71a9ba5c51bf.png">

### after
<img width="715" alt="border-after" src="https://user-images.githubusercontent.com/2096033/48445827-960dcc80-e765-11e8-9088-dc5ae5e4ea8c.png">

