### PR TITLE
sites/github: Fix background color of .gh-header elements

### DIFF
--- a/css/apprentice/apprentice-all-sites.css
+++ b/css/apprentice/apprentice-all-sites.css
@@ -189,6 +189,9 @@ a.filter-item:hover,
   background-color: #272727 !important;
   color: #ff8700 !important;
 }
+.gh-header {
+  background-color: #262626 !important;
+}
 .gh-header-number {
   color: #585858 !important;
 }

--- a/css/apprentice/apprentice-github.css
+++ b/css/apprentice/apprentice-github.css
@@ -121,6 +121,9 @@ a.filter-item:hover,
   background-color: #272727 !important;
   color: #ff8700 !important;
 }
+.gh-header {
+  background-color: #262626 !important;
+}
 .gh-header-number {
   color: #585858 !important;
 }

--- a/css/darculized/darculized-all-sites.css
+++ b/css/darculized/darculized-all-sites.css
@@ -189,6 +189,9 @@ a.filter-item:hover,
   background-color: #2e2e2e !important;
   color: #a6aaab !important;
 }
+.gh-header {
+  background-color: #262626 !important;
+}
 .gh-header-number {
   color: #5e6263 !important;
 }

--- a/css/darculized/darculized-github.css
+++ b/css/darculized/darculized-github.css
@@ -121,6 +121,9 @@ a.filter-item:hover,
   background-color: #2e2e2e !important;
   color: #a6aaab !important;
 }
+.gh-header {
+  background-color: #262626 !important;
+}
 .gh-header-number {
   color: #5e6263 !important;
 }

--- a/css/gruvbox/gruvbox-all-sites.css
+++ b/css/gruvbox/gruvbox-all-sites.css
@@ -189,6 +189,9 @@ a.filter-item:hover,
   background-color: #3c3836 !important;
   color: #8ec07c !important;
 }
+.gh-header {
+  background-color: #282828 !important;
+}
 .gh-header-number {
   color: #b8bb26 !important;
 }

--- a/css/gruvbox/gruvbox-github.css
+++ b/css/gruvbox/gruvbox-github.css
@@ -121,6 +121,9 @@ a.filter-item:hover,
   background-color: #3c3836 !important;
   color: #8ec07c !important;
 }
+.gh-header {
+  background-color: #282828 !important;
+}
 .gh-header-number {
   color: #b8bb26 !important;
 }

--- a/css/solarized-dark/solarized-dark-all-sites.css
+++ b/css/solarized-dark/solarized-dark-all-sites.css
@@ -189,6 +189,9 @@ a.filter-item:hover,
   background-color: #073642 !important;
   color: #93a1a1 !important;
 }
+.gh-header {
+  background-color: #002b36 !important;
+}
 .gh-header-number {
   color: #586e75 !important;
 }

--- a/css/solarized-dark/solarized-dark-github.css
+++ b/css/solarized-dark/solarized-dark-github.css
@@ -121,6 +121,9 @@ a.filter-item:hover,
   background-color: #073642 !important;
   color: #93a1a1 !important;
 }
+.gh-header {
+  background-color: #002b36 !important;
+}
 .gh-header-number {
   color: #586e75 !important;
 }

--- a/css/solarized-light/solarized-light-all-sites.css
+++ b/css/solarized-light/solarized-light-all-sites.css
@@ -189,6 +189,9 @@ a.filter-item:hover,
   background-color: #eee8d5 !important;
   color: #586e75 !important;
 }
+.gh-header {
+  background-color: #fdf6e3 !important;
+}
 .gh-header-number {
   color: #93a1a1 !important;
 }

--- a/css/solarized-light/solarized-light-github.css
+++ b/css/solarized-light/solarized-light-github.css
@@ -121,6 +121,9 @@ a.filter-item:hover,
   background-color: #eee8d5 !important;
   color: #586e75 !important;
 }
+.gh-header {
+  background-color: #fdf6e3 !important;
+}
 .gh-header-number {
   color: #93a1a1 !important;
 }

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -100,6 +100,9 @@ a.filter-item
     background-color highlight
     color emphasized
 
+.gh-header
+    background-color()
+
 .gh-header-number
     color comment
 


### PR DESCRIPTION
Fixes problems with the `.gh-header` element.

## Before
![2018-12-16-19-22-50_3840x2160](https://user-images.githubusercontent.com/1834516/50057262-30e43700-0168-11e9-9b17-a3ccd35d3a06.png)

## After
![2018-12-16-19-22-23_3840x2160](https://user-images.githubusercontent.com/1834516/50057266-3a6d9f00-0168-11e9-98db-33ee6828785c.png)
