### PR TITLE
fix github repo header color

### DIFF
--- a/css/apprentice/apprentice-all-sites.css
+++ b/css/apprentice/apprentice-all-sites.css
@@ -842,6 +842,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #272727 !important;
 }
+.pt-3 {
+  background-color: #272727 !important;
+}
 .repository-content .RecentBranches {
   background-color: #272727 !important;
   border-color: #800080 !important;

--- a/css/apprentice/apprentice-bigblow.css
+++ b/css/apprentice/apprentice-bigblow.css
@@ -206,8 +206,8 @@ a:hover {
   display: block;
 }
 #toTop {
-  top: -100px;
-  position: fixed;
+  top: -100px /* together with this to put the div at the top */;
+  position: fixed /* this is the magic */;
   text-align: center;
   z-index: 999;
   display: none;

--- a/css/apprentice/apprentice-github.css
+++ b/css/apprentice/apprentice-github.css
@@ -774,6 +774,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #272727 !important;
 }
+.pt-3 {
+  background-color: #272727 !important;
+}
 .repository-content .RecentBranches {
   background-color: #272727 !important;
   border-color: #800080 !important;

--- a/css/darculized/darculized-all-sites.css
+++ b/css/darculized/darculized-all-sites.css
@@ -842,6 +842,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #2e2e2e !important;
 }
+.pt-3 {
+  background-color: #2e2e2e !important;
+}
 .repository-content .RecentBranches {
   background-color: #2e2e2e !important;
   border-color: #909396 !important;

--- a/css/darculized/darculized-bigblow.css
+++ b/css/darculized/darculized-bigblow.css
@@ -206,8 +206,8 @@ a:hover {
   display: block;
 }
 #toTop {
-  top: -100px;
-  position: fixed;
+  top: -100px /* together with this to put the div at the top */;
+  position: fixed /* this is the magic */;
   text-align: center;
   z-index: 999;
   display: none;

--- a/css/darculized/darculized-github.css
+++ b/css/darculized/darculized-github.css
@@ -774,6 +774,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #2e2e2e !important;
 }
+.pt-3 {
+  background-color: #2e2e2e !important;
+}
 .repository-content .RecentBranches {
   background-color: #2e2e2e !important;
   border-color: #909396 !important;

--- a/css/gruvbox/gruvbox-all-sites.css
+++ b/css/gruvbox/gruvbox-all-sites.css
@@ -842,6 +842,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #3c3836 !important;
 }
+.pt-3 {
+  background-color: #3c3836 !important;
+}
 .repository-content .RecentBranches {
   background-color: #3c3836 !important;
   border-color: #fabd2f !important;

--- a/css/gruvbox/gruvbox-bigblow.css
+++ b/css/gruvbox/gruvbox-bigblow.css
@@ -206,8 +206,8 @@ a:hover {
   display: block;
 }
 #toTop {
-  top: -100px;
-  position: fixed;
+  top: -100px /* together with this to put the div at the top */;
+  position: fixed /* this is the magic */;
   text-align: center;
   z-index: 999;
   display: none;

--- a/css/gruvbox/gruvbox-github.css
+++ b/css/gruvbox/gruvbox-github.css
@@ -774,6 +774,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #3c3836 !important;
 }
+.pt-3 {
+  background-color: #3c3836 !important;
+}
 .repository-content .RecentBranches {
   background-color: #3c3836 !important;
   border-color: #fabd2f !important;

--- a/css/solarized-dark/solarized-dark-all-sites.css
+++ b/css/solarized-dark/solarized-dark-all-sites.css
@@ -842,6 +842,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #073642 !important;
 }
+.pt-3 {
+  background-color: #073642 !important;
+}
 .repository-content .RecentBranches {
   background-color: #073642 !important;
   border-color: #657b83 !important;

--- a/css/solarized-dark/solarized-dark-bigblow.css
+++ b/css/solarized-dark/solarized-dark-bigblow.css
@@ -206,8 +206,8 @@ a:hover {
   display: block;
 }
 #toTop {
-  top: -100px;
-  position: fixed;
+  top: -100px /* together with this to put the div at the top */;
+  position: fixed /* this is the magic */;
   text-align: center;
   z-index: 999;
   display: none;

--- a/css/solarized-dark/solarized-dark-github.css
+++ b/css/solarized-dark/solarized-dark-github.css
@@ -774,6 +774,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #073642 !important;
 }
+.pt-3 {
+  background-color: #073642 !important;
+}
 .repository-content .RecentBranches {
   background-color: #073642 !important;
   border-color: #657b83 !important;

--- a/css/solarized-light/solarized-light-all-sites.css
+++ b/css/solarized-light/solarized-light-all-sites.css
@@ -842,6 +842,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #eee8d5 !important;
 }
+.pt-3 {
+  background-color: #eee8d5 !important;
+}
 .repository-content .RecentBranches {
   background-color: #eee8d5 !important;
   border-color: #839496 !important;

--- a/css/solarized-light/solarized-light-bigblow.css
+++ b/css/solarized-light/solarized-light-bigblow.css
@@ -206,8 +206,8 @@ a:hover {
   display: block;
 }
 #toTop {
-  top: -100px;
-  position: fixed;
+  top: -100px /* together with this to put the div at the top */;
+  position: fixed /* this is the magic */;
   text-align: center;
   z-index: 999;
   display: none;

--- a/css/solarized-light/solarized-light-github.css
+++ b/css/solarized-light/solarized-light-github.css
@@ -774,6 +774,9 @@ ul.comparison-list {
 .pagehead.repohead {
   background-color: #eee8d5 !important;
 }
+.pt-3 {
+  background-color: #eee8d5 !important;
+}
 .repository-content .RecentBranches {
   background-color: #eee8d5 !important;
   border-color: #839496 !important;

--- a/sites/github.styl
+++ b/sites/github.styl
@@ -792,6 +792,9 @@ ul.comparison-list
 .pagehead.repohead
     background-color highlight
 
+.pt-3
+    background-color color-background-highlight
+
 .repository-content .RecentBranches
     background-color highlight
     border-color()


### PR DESCRIPTION
The repo view on Github still had the top bar black, instead of a suitable blue for the solarized dark theme. Now it fits with the rest of the theme.